### PR TITLE
Use public method instead of deprecated protected property

### DIFF
--- a/src/View/Helper/InlineCssHelper.php
+++ b/src/View/Helper/InlineCssHelper.php
@@ -15,7 +15,7 @@ class InlineCssHelper extends Helper
      */
     public function afterLayout(\Cake\Event\Event $event, $layoutFile)
     {
-        $content = $this->_View->Blocks->get('content');
+        $content = $this->_View->fetch('content');
 
         if (!isset($this->InlineCss)) {
             $this->InlineCss = new CssToInlineStyles();
@@ -26,7 +26,7 @@ class InlineCssHelper extends Helper
         $this->InlineCss->setUseInlineStylesBlock(true);
         $content = $this->InlineCss->convert();
 
-        $this->_View->Blocks->set('content', $content);
+        $this->_View->assign('content', $content);
 
         return;
     }


### PR DESCRIPTION
Hi thanks for the package.

With cakephp 3.7 public access to the `Block` property is deprecated. I adjusted the lines accordingly.

